### PR TITLE
Fix implicit declaration of xmm_free in xmmlib.c

### DIFF
--- a/include/vorbis/codec.h
+++ b/include/vorbis/codec.h
@@ -61,6 +61,7 @@ typedef struct vorbis_dsp_state{
 
   float **pcm;
   float **pcmret;
+  float *preextrapolate_work;
   int      pcm_storage;
   int      pcm_current;
   int      pcm_returned;

--- a/lib/block.c
+++ b/lib/block.c
@@ -394,6 +394,7 @@ void vorbis_dsp_clear(vorbis_dsp_state *v){
           if(v->pcm[i])_ogg_free(v->pcm[i]);
       _ogg_free(v->pcm);
       if(v->pcmret)_ogg_free(v->pcmret);
+      if(v->preextrapolate_work)_ogg_free(v->preextrapolate_work);
     }
 
     if(b){
@@ -439,11 +440,18 @@ static void _preextrapolate_helper(vorbis_dsp_state *v){
   int i;
   int order=16;
   float *lpc=alloca(order*sizeof(*lpc));
-  float *work=alloca(v->pcm_current*sizeof(*work));
+  float *work;
+  int workbuf=v->pcm_current*sizeof(*work);
   long j;
   v->preextrapolate=1;
 
-  if(v->pcm_current-v->centerW>order*2){ /* safety */
+  if(workbuf<256*1024)
+    work=alloca(workbuf);
+  else
+    /* workbuf is too big to safely allocate on the stack */
+    work=v->preextrapolate_work=_ogg_realloc(v->preextrapolate_work,workbuf);
+
+  if(v->pcm_current-v->centerW>order*2 && work){ /* safety */
     for(i=0;i<v->vi->channels;i++){
       /* need to run the extrapolation in reverse! */
       for(j=0;j<v->pcm_current;j++)

--- a/lib/codebook.c
+++ b/lib/codebook.c
@@ -77,7 +77,7 @@ static const unsigned long mask[]=
 
 #if	!defined(_USRDLL)
 /* Takes only up to 32 bits. */
-STIN vorbis_oggpack_write(oggpack_buffer *b, unsigned long value, int bits)
+STIN void vorbis_oggpack_write(oggpack_buffer *b, unsigned long value, int bits)
 {
 	uint32_t lvalue, hvalue;
 	if(b->endbyte+4>=b->storage){

--- a/lib/xmmlib.c
+++ b/lib/xmmlib.c
@@ -199,6 +199,18 @@ void* xmm_calloc(size_t nitems, size_t size)
 	return	(void*)t_RetPtr;
 }
 /*---------------------------------------------------------------------------
+// 16Byte Allignment free
+//-------------------------------------------------------------------------*/
+void xmm_free(void* a_AlignedPtr)
+{
+    if(a_AlignedPtr)
+#ifdef _WIN32
+        _aligned_free(a_AlignedPtr);
+#else
+        free(((void**)a_AlignedPtr)[-2]);
+#endif
+}
+/*---------------------------------------------------------------------------
 // 16Byte Allignment realloc
 //-------------------------------------------------------------------------*/
 void* xmm_realloc(void *block, size_t size)
@@ -215,18 +227,6 @@ void* xmm_realloc(void *block, size_t size)
 	memcpy(newblock, block, blsize);
 	xmm_free(block);
 	return newblock;
-#endif
-}
-/*---------------------------------------------------------------------------
-// 16Byte Allignment free
-//-------------------------------------------------------------------------*/
-void xmm_free(void* a_AlignedPtr)
-{
-	if(a_AlignedPtr)
-#ifdef _WIN32
-		_aligned_free(a_AlignedPtr);
-#else
-		free(((void**)a_AlignedPtr)[-2]);
 #endif
 }
 /*---------------------------------------------------------------------------

--- a/lib/xmmlib.c
+++ b/lib/xmmlib.c
@@ -126,7 +126,7 @@ void* xmm_malloc(size_t size)
 	void* p1 = (void*)malloc(size + offset);
 	void** p2 = (void**)(((size_t)(p1) + offset) & ~15);
 	if (p1 == NULL) return NULL;
-	p2[-1] = size;
+	p2[-1] = (void*)size;
 	p2[-2] = p1;
 	return p2;
 #endif

--- a/lib/xmmlib.h
+++ b/lib/xmmlib.h
@@ -120,9 +120,9 @@ extern const int bitCountTable[16];
 
 extern void* xmm_malloc(size_t);
 extern void* xmm_calloc(size_t, size_t);
+extern void xmm_free(void*);
 extern void* xmm_realloc(void*, size_t);
 extern void* xmm_align(void*);
-extern void xmm_free(void*);
 
 STIN __m128 _mm_todB_ps(__m128 x)
 {


### PR DESCRIPTION
Thank you for your effort in maintaining this (in my opinion) underestimated but excellent modification of the Vorbis reference implementation.

When I've tried to cross-compile it for ARM64 MacOS targets from a MacOS x64 host, I've found the following errors, that do not happen when doing a native build for x64 MacOS:

![image](https://user-images.githubusercontent.com/7822554/184727775-3689a28c-b5b9-4aac-bd6a-c886ae7738c6.png)

I guess that the ARM64 MacOS `cc` is more strict about these implicit declarations. This PR avoids that implicit declaration, which is enough to get everything building fine.